### PR TITLE
Made sign in button not take the width of page

### DIFF
--- a/components/Signin.js
+++ b/components/Signin.js
@@ -22,7 +22,7 @@ function Signin() {
           <h6>Want to create teams for your next Game Night? Well, you are in the right place!!</h6>
           <p>Click the button below to get started!</p>
         </div>
-        <Button type="button" size="lg" className="copy-btn" onClick={signIn}>
+        <Button type="button" size="lg" className="copy-btn" onClick={signIn} style={{ maxWidth: '300px', margin: '0px auto' }}>
           Sign In
         </Button>
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
The button on the sign in page was taking the width of the page and that was not a pleasant view.

## Related Issue
#23 

## Motivation and Context
The motivation was to create a an appealing view for users.

## How Can This Be Tested?
Go to the app and you will see the sign in button is a reasonable width.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
